### PR TITLE
Batch Editor

### DIFF
--- a/src/universal/batch-edit.c
+++ b/src/universal/batch-edit.c
@@ -21,51 +21,11 @@ int limit_num(int min, int max, int max_digits)
     return (int)num;
 }
 
-int pick_ball(enum Generation sav_gen, int isBank)
-{
-    char *balls[26] = {
-        "Master Ball", "Ultra Ball", "Great Ball", "Poke Ball",
-        "Safari Ball", "Net Ball", "Dive Ball", "Nest Ball",
-        "Repeat Ball", "Timer Ball", "Luxury Ball", "Premier Ball",
-        "Dusk Ball", "Heal Ball", "Quick Ball", "Cherish Ball",
-        "Fast Ball", "Level Ball", "Lure Ball", "Heavy Ball",
-        "Love Ball", "Friend Ball", "Moon Ball", "Sport Ball",
-        "Dream Ball", "Beast Ball"};
-    int ball = 0;
-    int limit = 26;
-    if (!isBank)
-    {
-        if (sav_gen == GEN_FOUR)
-        {
-            limit = 24;
-        }
-        else if (sav_gen == GEN_FIVE || sav_gen == GEN_SIX)
-        {
-            limit = 25;
-        }
-        else if (sav_gen == GEN_LGPE)
-        {
-            limit = 16;
-        }
-    }
-    while (1)
-    {
-        ball = gui_menu_20x2("Pick a ball", limit, balls);
-        if (isBank || sav_gen != GEN_LGPE || (ball < 4 || ball == 11 || ball == 15))
-        {
-            break;
-        }
-        gui_warn("Not a legal ball for LGPE\nPlease pick another");
-    }
-    ball += 1;
-    return ball;
-}
-
 int main(int argc, char **argv)
 {
     unsigned char version = *argv[2];
     enum Generation gen_sav;
-    int limit_lang = 9, limit_name = 13;
+    int limit_lang = 9, limit_name = 13, limit_ball = 26;
 
     switch (version)
     {
@@ -77,6 +37,7 @@ int main(int argc, char **argv)
             gen_sav = GEN_FOUR;
             limit_lang = 7;
             limit_name = 8;
+            limit_ball = 24;
             break;
         case 20: // W
         case 21: // B
@@ -85,6 +46,7 @@ int main(int argc, char **argv)
             gen_sav = GEN_FIVE;
             limit_lang = 7;
             limit_name = 8;
+            limit_ball = 25;
             break;
         case 24: // X
         case 25: // Y
@@ -92,6 +54,7 @@ int main(int argc, char **argv)
         case 27: // OR
             gen_sav = GEN_SIX;
             limit_lang = 7;
+            limit_ball = 25;
             break;
         case 30: // Su
         case 31: // Mo
@@ -102,6 +65,7 @@ int main(int argc, char **argv)
         case 42: // LGP
         case 43: // LGE
             gen_sav = GEN_LGPE;
+            limit_ball = 6;
             break;
         case 44: // SW
         case 45: // SH
@@ -179,6 +143,22 @@ int main(int argc, char **argv)
         "Timid", "Hasty", "Serious", "Jolly", "Naive",
         "Modest", "Mild", "Quiet", "Bashful", "Rash",
         "Calm", "Gentle", "Sassy", "Careful", "Quirky"};
+    char *balls[26] = {
+        "Cherish Ball", "Poke Ball", "Great Ball", "Ultra Ball",
+        "Master Ball", "Premier Ball", "Dive Ball", "Dusk Ball",
+        "Heal Ball", "Luxury Ball", "Nest Ball", "Net Ball",
+        "Quick Ball", "Repeat Ball", "Safari Ball", "Timer Ball",
+        "Fast Ball", "Friend Ball", "Heavy Ball", "Level Ball",
+        "Love Ball", "Lure Ball", "Moon Ball", "Sport Ball",
+        "Dream Ball", "Beast Ball"};
+    int ball_ids[26] = {
+        16, 4, 3, 2,
+        1, 12, 7, 13,
+        14, 11, 8, 6,
+        15, 9, 5, 10,
+        17, 22, 20, 18,
+        21, 19, 23, 24,
+        25, 26};
     enum Generation gen_pkm;
     char name[0x27] = {'\0'};
 
@@ -211,7 +191,7 @@ int main(int argc, char **argv)
         while (prop)
         {
             skip = 0;
-            prop = gui_menu_20x2("Pick a property to edit\n\nWarning: these edits will affect\nEVERYTHING in your save/bank,\nand may result in illegal Pokémon", props_count, props);
+            prop = gui_menu_20x2("Pick a property to edit\n\nWarning: these edits will affect\nEVERYTHING in the boxes of\nyour save/bank, and may result\nin illegal Pokémon", props_count, props);
             switch (prop)
             {
                 case 2: // OT Name
@@ -229,7 +209,7 @@ int main(int argc, char **argv)
                     val_1 = limit_num(1, 100, 3);
                     break;
                 case 7: // Shiny
-                    val_1 = gui_menu_20x2("Shiny or not?", 2, shininess);
+                    val_1 = 1 - gui_menu_20x2("Shiny or not?\n\nWarning:\nShiny may take a while", 2, shininess);
                     break;
                 case 8: // all IVs
                     val_1 = limit_num(0, 31, 2);
@@ -247,7 +227,8 @@ int main(int argc, char **argv)
                     val_1 = gui_menu_20x2("Pick a nature", 25, natures);
                     break;
                 case 12: // Ball
-                    val_1 = pick_ball(gen_sav, target != 1);
+                    choice = gui_menu_20x2("Pick a ball", target == 1 ? limit_ball : 26, balls);
+                    val_1 = ball_ids[choice];
                     break;
                 case 13: // PP Ups
                     val_1 = limit_num(0, 3, 1);
@@ -257,6 +238,10 @@ int main(int argc, char **argv)
                     break;
                 case 15: // Random PID
                     choice = gui_choice("Should shiny Pokémon remain shiny?");
+                    if (choice)
+                    {
+                        gui_warn("This may take some time");
+                    }
                     break;
                 // case 16: // Item
                 //     // int (0-?)

--- a/src/universal/batch-edit.c
+++ b/src/universal/batch-edit.c
@@ -1,0 +1,320 @@
+#include <pksm.h>
+#include <unistd.h>
+#include <stdlib.h> /* rand */
+#include <stdio.h> /* sprintf */
+#include <time.h> /* time */
+
+int limit_num(int min, int max, int max_digits)
+{
+    unsigned int num;
+    char *hint[35] = {'\0'};
+    sprintf(hint, "Enter a number from %d to %d", min, max);
+    while (1)
+    {
+        gui_warn(hint);
+        gui_numpad(&num, hint, max_digits);
+        if (num >= min && num <= max)
+        {
+            break;
+        }
+        gui_warn("Invalid input\nPlease try again.");
+    }
+    return (int)num;
+}
+
+int main(int argc, char **argv)
+{
+    unsigned char version = *argv[2];
+    enum Generation gen_sav;
+
+    switch (version)
+    {
+        case 10: // D
+        case 11: // P
+        case 12: // PT
+        case 7:  // HG
+        case 8:  // SS
+            gen_sav = GEN_FOUR;
+            break;
+        case 20: // W
+        case 21: // B
+        case 22: // W2
+        case 23: // B2
+            gen_sav = GEN_FIVE;
+            break;
+        case 24: // X
+        case 25: // Y
+        case 26: // AS
+        case 27: // OR
+            gen_sav = GEN_SIX;
+            break;
+        case 30: // Su
+        case 31: // Mo
+        case 32: // US
+        case 33: // UM
+            gen_sav = GEN_SEVEN;
+            break;
+        case 42: // LGP
+        case 43: // LGE
+            gen_sav = GEN_LGPE;
+            break;
+        case 44: // SW
+        case 45: // SH
+            gen_sav = GEN_EIGHT;
+            break;
+        default:
+            gui_warn("This script doesn't work\non this game.");
+            return 1;
+    }
+
+    char *targets = {
+        "Exit script",
+        "Use save boxes",
+        "Use current bank",
+        "Choose bank"
+    };
+    char *props[17] = {
+        "Exit Script",
+        "Previous menu",
+        "Set OT name",
+        "Set OT TID",
+        "Set OT SID",
+        "Set OT Gender",
+        "Set Level",
+        "Set Shiny",
+        "Set all IVs",
+        "Set Language",
+        "Set Pokerus",
+        "Set Nature",
+        "Set Ball",
+        "Set PP Ups",
+        "Clear moves",
+        "Randomize PIDs",
+        "Set Item"
+    };
+    enum PKX_Field fields[17] = {
+        NICKNAME, // filler
+        GENDER, // filler
+        OT_NAME,
+        TID,
+        SID,
+        OT_GENDER,
+        LEVEL,
+        SHINY,
+        IV_HP,
+        LANGUAGE,
+        POKERUS,
+        NATURE,
+        BALL,
+        PP_UPS,
+        MOVE,
+        PID,
+        ITEM
+    };
+    char *languages[9] = {
+        "\u65e5\u672c\u8a9e",          // JAP
+        "English",                     // ENG
+        "Fran\u00e7ais",               // FRE
+        "Italiano",                    // ITA
+        "Deutsche",                    // GER
+        "Espa\u00f1ol",                // SPA
+        "\ud55c\uad6d\uc5b4",          // KOR
+        "\u4e2d\u6587 (\u7b80\u4f53)", // CHS?
+        "\u4e2d\u6587 (\u7e41\u9ad4)"  // CHT?
+    };
+    char *pokerus[3] = {"Infected", "Cured", "Not infected"};
+    char *genders[2] = {"Male", "Female"};
+    char *shininess[2] = {"Shiny", "Normal"};
+    char *natures[25] = {
+        "Hardy", "Lonely", "Brave", "Adamant", "Naughty",
+        "Bold", "Docile", "Relaxed", "Impish", "Lax",
+        "Timid", "Hasty", "Serious", "Jolly", "Naive",
+        "Modest", "Mild", "Quiet", "Bashful", "Rash",
+        "Calm", "Gentle", "Sassy", "Careful", "Quirky"};
+    char *balls[26] = {
+        "Master Ball", "Ultra Ball", "Great Ball", "Poke Ball",
+        "Safari Ball", "Net Ball", "Dive Ball", "Nest Ball",
+        "Repeat Ball", "Timer Ball", "Luxury Ball", "Premier Ball",
+        "Dusk Ball", "Heal Ball", "Quick Ball", "Cherish Ball",
+        "Fast Ball", "Level Ball", "Lure Ball", "Heavy Ball",
+        "Love Ball", "Friend Ball", "Moon Ball", "Sport Ball",
+        "Dream Ball", "Beast Ball"};
+    int boxes, box, slot,
+        pkm_size = pkx_box_size(gen_sav),
+        target = -1, prop = -1,
+        choice, val_1, val_2;
+    enum Generation gen_pkm;
+    char *name[0x27] {'\0'};
+
+    srand(time(0) + version);
+
+    gui_warn("Edits made by this script may result in illegal Pokémon");
+    while (target && prop)
+    {
+        target = gui_menu_20x2("Pick a group of Pokémon to edit", 4, targets);
+        if (target == 0)
+        {
+            break;
+        }
+        else if (target == 3)
+        {
+            bank_select();
+        }
+
+        if (target == 1)
+        {
+            boxes = sav_get_max(MAX_BOXES);
+            gen_pkm = gen_sav;
+            sav_box_decrypt();
+        }
+        else
+        {
+            boxes = bank_get_size();
+        }
+
+
+        while (prop)
+        {
+            prop = gui_menu_20x2("Pick a property to edit", 15, props);
+            if (prop < 2)
+            {
+                break;
+            }
+
+            switch (prop)
+            {
+                case 2: // OT Name
+                    gui_keyboard(&name, "Enter an OT name", 0xD);
+                    break;
+                case 3: // OT TID
+                case 4: // OT SID
+                    gui_warn("IDs must be the old style\nin the range of 0 to 65535");
+                    val_1 = limit_num(0, 65535, 5);
+                    break;
+                case 5: // OT Gender
+                    val_1 = gui_menu_20x2("Choose OT gender", 2, genders);
+                    break;
+                case 6: // Level
+                    val_1 = limit_num(1, 100, 3);
+                    break;
+                case 7: // Shiny
+                    choice = gui_menu_20x2("Shiny or not?", 2, shininess);
+                    val_1 = choice - 2;
+                    break;
+                case 8: // all IVs
+                    val_1 = limit_num(0, 31, 2);
+                    break;
+                case 9: // Language
+                    choice = gui_menu_20x2("Choose a language", version < 30 ? 7 : 9, languages);
+                    val_1 = choice + (choice >= 6 ? 2 : 1);
+                    break;
+                case 10: // Pokerus
+                    choice = gui_menu_20x2("Pick a Pokerus option", 3, pokerus);
+                    val_1 = choice < 2 ? 0xF : 0; // strain
+                    val_2 = choice == 0 ? 4 : 0; // days
+                    break;
+                case 11: // Nature
+                    val_1 = gui_menu_20x2("Pick a nature", 25, natures);
+                    break;
+                case 12: // Ball
+                    val_1 = gui_menu_20x2("Pick a ball", 18, balls) + 1;
+                    break;
+                case 13: // PP Ups
+                    val_1 = limit_num(0, 3, 1);
+                    break;
+                case 14: // Clear moves
+                    val_1 = 0;
+                    break;
+                case 15: // Random PID
+                    break;
+                // case 16: // Item
+                //     // int (0-?)
+                //     break;
+                default:
+                    gui_warn("This edit type is not available.\nPlease choose another.");
+                    continue;
+            }
+
+            for (int box = 0; box < boxes; box++)
+            {
+                for (int slot = 0; slot < 30; slot++)
+                {
+                    if (target == 1 && gen_sav == GEN_LGPE && box * 30 + slot == 1000)
+                    {
+                        break;
+                    }
+
+                    char *pkm;
+                    if (target == 1)
+                    {
+                        pkm = malloc(pkm_size);
+                        sav_get_pkx(pkm, box, slot);
+                    }
+                    else
+                    {
+                        pkm = bank_get_pkx(gen_pkm, box, slot);
+                    }
+
+                    if (prop == 15 && gen_pkm != GEN_FOUR && gen_pkm != GEN_THREE)
+                    {
+                        val_1 = (rand() & 0xFFFF) << 16;
+                        val_1 |= (rand() & 0xFFFF);
+                    }
+
+                    if (prop == 1) // OT name
+                    {
+                        pkx_set_value(pkm, gen_pkm, fields[prop], name);
+                    }
+                    else if (prop == 8) // IVs
+                    {
+                        for (int i = 0; i < 6; i++)
+                        {
+                            pkx_set_value(pkm, gen_pkm, fields[prop] + i, val_1);
+                        }
+                    }
+                    else if (prop == 10) // Pokerus
+                    {
+                        pkx_set_value(pkm, gen_pkm, fields[prop], val_1, val_2);
+                    }
+                    else if (prop == 13 || prop == 14) // PP Ups, Clear moves
+                    {
+                        for (int i = 0; i < 4; i++)
+                        {
+                            pkx_set_value(pkm, gen_pkm, fields[prop], i, val_1);
+                        }
+                        if (prop == 14)
+                        {
+                            pkx_set_value(pkm, gen_pkm, fields[prop], 0, 1);
+                        }
+                    }
+                    else if (prop == 15 && (gen_pkm == GEN_FOUR || gen_pkm == GEN_THREE))
+                    {
+                        // Gen 3/4 PID is rerolled when setting PID-dependent value
+                        pkx_set_value(pkm, gen_pkm, fields[1], pkx_get_value(pkm, gen_pkm, fields[1]));
+                    }
+                    else
+                    {
+                        pkx_set_value(pkm, gen_pkm, fields[prop], val_1);
+                    }
+
+                    if (target == 1)
+                    {
+                        sav_inject_pkx(pkm, gen_pkm, box, slot, 1);
+                    }
+                    else
+                    {
+                        bank_inject_pkx(pkm, gen_pkm, box, slot);
+                    }
+                    free(pkm);
+                }
+            }
+        }
+
+        if (target == 1)
+        {
+            sav_box_encrypt();
+        }
+    }
+
+    return 0;
+}

--- a/src/universal/batch-edit.c
+++ b/src/universal/batch-edit.c
@@ -147,10 +147,10 @@ int main(int argc, char **argv)
 
     srand(time(0) + version);
 
-    gui_warn("Edits made by this script may result in illegal Pokémon");
+    gui_warn("Edits made by this script may result\nin illegal Pokémon");
     while (target && prop)
     {
-        target = gui_menu_20x2("Pick a group of Pokémon to edit", 4, targets);
+        target = gui_menu_20x2("Pick a group of Pokémon to edit\n\nWarning: these edits will affect\nEVERYTHING in save/bank", 4, targets);
         if (target == 0)
         {
             break;
@@ -171,10 +171,9 @@ int main(int argc, char **argv)
             boxes = bank_get_size();
         }
 
-
         while (prop)
         {
-            prop = gui_menu_20x2("Pick a property to edit", 15, props);
+            prop = gui_menu_20x2("Pick a property to edit", 17, props);
             if (prop < 2)
             {
                 break;
@@ -183,7 +182,7 @@ int main(int argc, char **argv)
             switch (prop)
             {
                 case 2: // OT Name
-                    gui_keyboard(&name, "Enter an OT name", 0xD);
+                    gui_keyboard(name, "Enter an OT name", 0xD);
                     break;
                 case 3: // OT TID
                 case 4: // OT SID
@@ -230,7 +229,10 @@ int main(int argc, char **argv)
                 //     // int (0-?)
                 //     break;
                 default:
-                    gui_warn("This edit type is not available.\nPlease choose another.");
+                    if (prop > 1)
+                    {
+                        gui_warn("This edit type is not available.\nPlease choose another.");
+                    }
                     continue;
             }
 
@@ -266,7 +268,7 @@ int main(int argc, char **argv)
                         val_1 |= (rand() & 0xFFFF);
                     }
 
-                    if (prop == 1) // OT name
+                    if (prop == 2) // OT name
                     {
                         pkx_set_value(pkm, gen_pkm, fields[prop], name);
                     }

--- a/src/universal/batch-edit.c
+++ b/src/universal/batch-edit.c
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
         target = -1, prop = -1,
         choice, val_1, val_2;
     enum Generation gen_pkm;
-    char *name[0x27] {'\0'};
+    char name[0x27] = {'\0'};
 
     srand(time(0) + version);
 

--- a/src/universal/batch-edit.c
+++ b/src/universal/batch-edit.c
@@ -21,10 +21,44 @@ int limit_num(int min, int max, int max_digits)
     return (int)num;
 }
 
+int pick_ball(enum Generation sav_gen, int isBank)
+{
+    char *balls[26] = {
+        "Master Ball", "Ultra Ball", "Great Ball", "Poke Ball",
+        "Safari Ball", "Net Ball", "Dive Ball", "Nest Ball",
+        "Repeat Ball", "Timer Ball", "Luxury Ball", "Premier Ball",
+        "Dusk Ball", "Heal Ball", "Quick Ball", "Cherish Ball",
+        "Fast Ball", "Level Ball", "Lure Ball", "Heavy Ball",
+        "Love Ball", "Friend Ball", "Moon Ball", "Sport Ball",
+        "Dream Ball", "Beast Ball"};
+    int ball = 0;
+    int limit = 26;
+    if (!isBank)
+    {
+        limit -= ((sav_gen == GEN_FOUR) + (sav_gen == GEN_FIVE || sav_gen == GEN_SIX));
+        if (sav_gen == GEN_LGPE)
+        {
+            limit = 15;
+        }
+    }
+    while (1)
+    {
+        ball = gui_menu_20x2("Pick a ball", limit, balls);
+        if (isBank || sav_gen != GEN_LGPE || (ball < 4 || ball != 11 || ball != 15))
+        {
+            break;
+        }
+        gui_warn("Not a legal ball for LGPE\nPlease pick another");
+    }
+    ball += 1;
+    return ball;
+}
+
 int main(int argc, char **argv)
 {
     unsigned char version = *argv[2];
     enum Generation gen_sav;
+    int limit_lang = 9, limit_name = 0xD;
 
     switch (version)
     {
@@ -34,18 +68,23 @@ int main(int argc, char **argv)
         case 7:  // HG
         case 8:  // SS
             gen_sav = GEN_FOUR;
+            limit_lang = 7;
+            limit_name = 8;
             break;
         case 20: // W
         case 21: // B
         case 22: // W2
         case 23: // B2
             gen_sav = GEN_FIVE;
+            limit_lang = 7;
+            limit_name = 8;
             break;
         case 24: // X
         case 25: // Y
         case 26: // AS
         case 27: // OR
             gen_sav = GEN_SIX;
+            limit_lang = 7;
             break;
         case 30: // Su
         case 31: // Mo
@@ -130,14 +169,6 @@ int main(int argc, char **argv)
         "Timid", "Hasty", "Serious", "Jolly", "Naive",
         "Modest", "Mild", "Quiet", "Bashful", "Rash",
         "Calm", "Gentle", "Sassy", "Careful", "Quirky"};
-    char *balls[26] = {
-        "Master Ball", "Ultra Ball", "Great Ball", "Poke Ball",
-        "Safari Ball", "Net Ball", "Dive Ball", "Nest Ball",
-        "Repeat Ball", "Timer Ball", "Luxury Ball", "Premier Ball",
-        "Dusk Ball", "Heal Ball", "Quick Ball", "Cherish Ball",
-        "Fast Ball", "Level Ball", "Lure Ball", "Heavy Ball",
-        "Love Ball", "Friend Ball", "Moon Ball", "Sport Ball",
-        "Dream Ball", "Beast Ball"};
     int boxes, skip, pkm_size = pkx_box_size(gen_sav),
         target = -1, prop = -1,
         choice = 0, val_1 = 0, val_2 = 0;
@@ -177,7 +208,7 @@ int main(int argc, char **argv)
             switch (prop)
             {
                 case 2: // OT Name
-                    gui_keyboard(name, "Enter an OT name", 0xD);
+                    gui_keyboard(name, "Enter an OT name", target == 1 ? limit_name : 0xD);
                     break;
                 case 3: // OT TID
                 case 4: // OT SID
@@ -198,7 +229,7 @@ int main(int argc, char **argv)
                     val_1 = limit_num(0, 31, 2);
                     break;
                 case 9: // Language
-                    choice = gui_menu_20x2("Choose a language", version < 30 ? 7 : 9, languages);
+                    choice = gui_menu_20x2("Choose a language", target == 1 ? limit_lang : 9, languages);
                     val_1 = choice + (choice >= 6 ? 2 : 1);
                     break;
                 case 10: // Pokerus
@@ -210,7 +241,7 @@ int main(int argc, char **argv)
                     val_1 = gui_menu_20x2("Pick a nature", 25, natures);
                     break;
                 case 12: // Ball
-                    val_1 = gui_menu_20x2("Pick a ball", 26, balls) + 1;
+                    val_1 = pick_ball(gen_sav, target != 1);
                     break;
                 case 13: // PP Ups
                     val_1 = limit_num(0, 3, 1);

--- a/src/universal/batch-edit.c
+++ b/src/universal/batch-edit.c
@@ -255,6 +255,12 @@ int main(int argc, char **argv)
                         pkm = bank_get_pkx(gen_pkm, box, slot);
                     }
 
+                    if (!pkx_is_valid(pkm, gen_pkm))
+                    {
+                        free(pkm);
+                        continue;
+                    }
+
                     if (prop == 15 && gen_pkm != GEN_FOUR && gen_pkm != GEN_THREE)
                     {
                         val_1 = (rand() & 0xFFFF) << 16;

--- a/src/universal/batch-edit.c
+++ b/src/universal/batch-edit.c
@@ -7,7 +7,7 @@
 int limit_num(int min, int max, int max_digits)
 {
     unsigned int num;
-    char *hint[35] = {'\0'};
+    char hint[35] = {'\0'};
     sprintf(hint, "Enter a number from %d to %d", min, max);
     while (1)
     {
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
             return 1;
     }
 
-    char *targets = {
+    char *targets[4] = {
         "Exit script",
         "Use save boxes",
         "Use current bank",
@@ -139,8 +139,7 @@ int main(int argc, char **argv)
         "Fast Ball", "Level Ball", "Lure Ball", "Heavy Ball",
         "Love Ball", "Friend Ball", "Moon Ball", "Sport Ball",
         "Dream Ball", "Beast Ball"};
-    int boxes, box, slot,
-        pkm_size = pkx_box_size(gen_sav),
+    int boxes, pkm_size = pkx_box_size(gen_sav),
         target = -1, prop = -1,
         choice, val_1, val_2;
     enum Generation gen_pkm;

--- a/src/universal/batch-edit.c
+++ b/src/universal/batch-edit.c
@@ -44,7 +44,7 @@ int pick_ball(enum Generation sav_gen, int isBank)
     while (1)
     {
         ball = gui_menu_20x2("Pick a ball", limit, balls);
-        if (isBank || sav_gen != GEN_LGPE || (ball < 4 || ball != 11 || ball != 15))
+        if (isBank || sav_gen != GEN_LGPE || (ball < 4 || ball == 11 || ball == 15))
         {
             break;
         }

--- a/src/universal/batch-edit.c
+++ b/src/universal/batch-edit.c
@@ -38,7 +38,7 @@ int pick_ball(enum Generation sav_gen, int isBank)
         limit -= ((sav_gen == GEN_FOUR) + (sav_gen == GEN_FIVE || sav_gen == GEN_SIX));
         if (sav_gen == GEN_LGPE)
         {
-            limit = 15;
+            limit = 16;
         }
     }
     while (1)

--- a/src/universal/batch-edit.c
+++ b/src/universal/batch-edit.c
@@ -210,7 +210,7 @@ int main(int argc, char **argv)
                     val_1 = gui_menu_20x2("Pick a nature", 25, natures);
                     break;
                 case 12: // Ball
-                    val_1 = gui_menu_20x2("Pick a ball", 18, balls) + 1;
+                    val_1 = gui_menu_20x2("Pick a ball", 26, balls) + 1;
                     break;
                 case 13: // PP Ups
                     val_1 = limit_num(0, 3, 1);

--- a/src/universal/batch-edit.c
+++ b/src/universal/batch-edit.c
@@ -256,7 +256,7 @@ int main(int argc, char **argv)
                         }
                         else
                         {
-                            pkm = bank_get_pkx(gen_pkm, box, slot);
+                            pkm = bank_get_pkx(&gen_pkm, box, slot);
                         }
 
                         if (!pkx_is_valid(pkm, gen_pkm))


### PR DESCRIPTION
Allows to making the same change to the entire save or selected bank.

Below is the list of support built-in to the script, with check marks denoting which features I've tested and are successfully working on the latest version of the script. Once testing is adequately complete, can be squashed and merged.

- Edit types
    - [x] OT name
    - [x] OT TID
    - [x] OT SID
    - [x] OT Gender
    - [x] Level
    - [x] Shiny
    - [x] all IVs
    - [x] Language
    - [x] Pokérus
    - [x] Nature
    - [x] Ball
    - [x] PP Ups
    - [x] Clear moves (moves 2-4 are cleared and move 1 is set to Pound)
    - [x] Randomize PIDs
- Supported targets
    - [x] Gen 4 (DP, PT, HGSS) - tested on PT
    - [x] Gen 5 (BW, B2W2) - tested on B2
    - [x] Gen 6 (XY, ORAS) - tested on X
    - [x] Gen 7 (SM, USUM) - tested on M
    - [ ] LGPE
    - [ ] SWSH
    - [x] bank